### PR TITLE
bin: fix startServer import

### DIFF
--- a/bin/cucumber-language-server.cjs
+++ b/bin/cucumber-language-server.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 require('source-map-support').install()
-const startServer = require('../dist/cjs/src/startServer')
+const { startServer } = require('../dist/cjs/src/startServer')
 
 const wasmUrls = {
   java: `node_modules/@cucumber/language-service/tree-sitter-java.wasm`,


### PR DESCRIPTION
<!---
Thanks for submitting a pull request!

The prompts below (the _bits in italics_) are for guidance to help you describe your change in a way that is most likely to make sense to other people when they are reviewing it. Still, it's just a guide, so feel free to delete anything that doesn't feel appropriate, and add anything additional that seems like it would probide useful context.

Please either replace the promopts with your own words, or delete them.
-->

# Description

It seems like the latest release broke the executable, where it's throwing the following exception:

```
/Users/williamboman/.local/share/nvim/lsp_servers/cucumber_language_server/node_modules/@cucumber/language-server/bin/cucumber-language-server.cjs:10
startServer(wasmUrls)
^
TypeError: startServer is not a function
    at Object.<anonymous> (/Users/williamboman/.local/share/nvim/lsp_servers/cucumber_language_server/node_modules/@cucumber/language-server/bin/cucumber-language-server.cjs:10:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```

# Motivation & context

_Why is this change required? What problem does it solve?
It fixes the import of `startServer`, which is not a default export.

## Type of change

<!--- Delete any options that are not relevant -->

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!--- 
Go over all the following points, and put an `x` in all the boxes that apply. 
-->

- [ ] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [ ] My change needed additional tests
  - [ ] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
