### PR TITLE
Export custom node and wasm entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for C#
+- Support for PHP
+
+### Changed
+- Remove external dependency on `@cucumber/language-service` - always use tree-sitter wasm
+
 ## [0.6.0] - 2022-04-26
 ### Changed
 - Use tree-sitter Node.js bindings instead of web (WASM) bindings.

--- a/bin/cucumber-language-server.cjs
+++ b/bin/cucumber-language-server.cjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
 require('source-map-support').install()
-const { startServer } = require('../dist/cjs/src/startServer')
-const { NodeParserAdapter } = require('@cucumber/language-service/node')
-startServer(new NodeParserAdapter())
+const { startNodeServer } = require('../dist/cjs/src/node/startNodeServer')
+startNodeServer()

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wasm",
+  "description": "Cucumber Language server using tree-sitter node bindings",
+  "main": "../dist/cjs/src/node/startNodeServer.js",
+  "module": "../dist/esm/src/node/startNodeServer.js",
+  "types": "../dist/esm/src/node/startNodeServer.d.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cucumber/cucumber-expressions": "^15.1.1",
         "@cucumber/gherkin-utils": "^7.0.0",
-        "@cucumber/language-service": "^0.14.4",
+        "@cucumber/language-service": "^0.15.0",
         "fast-glob": "3.2.11",
         "source-map-support": "0.5.21",
         "vscode-languageserver": "7.0.0",
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@cucumber/language-service": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-0.14.4.tgz",
-      "integrity": "sha512-L0cbjfXrGkgxfia0JOqA9hPOFbOihvxgulGt1IJofa/knMAxNZFQO8pSExEQBCjXmQMEnOdlP2c0iGyVwRD3rg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-0.15.0.tgz",
+      "integrity": "sha512-LSL4H2IDqfgiKdrAnQRBctJZ/6vKa7x6nkavsnrCH6xab9QFTFZMSnF2GGW/OLPi4M03BGg+ehZaWYNu4YcCtw==",
       "dependencies": {
         "@cucumber/cucumber-expressions": "^15.1.1",
         "@cucumber/gherkin": "^23.0.1",
@@ -244,6 +244,7 @@
         "tree-sitter": "0.20.0",
         "tree-sitter-c-sharp": "0.19.1",
         "tree-sitter-java": "0.19.1",
+        "tree-sitter-php": "0.19.0",
         "tree-sitter-typescript": "0.20.1",
         "vscode-languageserver-types": "3.17.0-next.10"
       },
@@ -6156,6 +6157,15 @@
         "nan": "^2.14.1"
       }
     },
+    "node_modules/tree-sitter-php": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.19.0.tgz",
+      "integrity": "sha512-YchOF4ai+CIP8AMHuNDohEOG4T+9+6YwVqyNwWS9+BIBze41D32V9FCc88/v4W5YRvvCdRqJk8V+hWtnCHrUcw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "nan": "^2.14.0"
+      }
+    },
     "node_modules/tree-sitter-typescript": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.20.1.tgz",
@@ -6915,9 +6925,9 @@
       "requires": {}
     },
     "@cucumber/language-service": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-0.14.4.tgz",
-      "integrity": "sha512-L0cbjfXrGkgxfia0JOqA9hPOFbOihvxgulGt1IJofa/knMAxNZFQO8pSExEQBCjXmQMEnOdlP2c0iGyVwRD3rg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-0.15.0.tgz",
+      "integrity": "sha512-LSL4H2IDqfgiKdrAnQRBctJZ/6vKa7x6nkavsnrCH6xab9QFTFZMSnF2GGW/OLPi4M03BGg+ehZaWYNu4YcCtw==",
       "requires": {
         "@cucumber/cucumber-expressions": "^15.1.1",
         "@cucumber/gherkin": "^23.0.1",
@@ -6929,6 +6939,7 @@
         "tree-sitter": "0.20.0",
         "tree-sitter-c-sharp": "0.19.1",
         "tree-sitter-java": "0.19.1",
+        "tree-sitter-php": "0.19.0",
         "tree-sitter-typescript": "0.20.1",
         "vscode-languageserver-types": "3.17.0-next.10"
       }
@@ -11368,6 +11379,14 @@
       "integrity": "sha512-yVm+4q1D4niaHcEf2iqhOcIaiSp3wxHjeC4eoLAqSQNVxSrhThmT1FEfM4yDgHV4XaxH+62xpKHCwYG9NzRt6Q==",
       "requires": {
         "nan": "^2.14.1"
+      }
+    },
+    "tree-sitter-php": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-php/-/tree-sitter-php-0.19.0.tgz",
+      "integrity": "sha512-YchOF4ai+CIP8AMHuNDohEOG4T+9+6YwVqyNwWS9+BIBze41D32V9FCc88/v4W5YRvvCdRqJk8V+hWtnCHrUcw==",
+      "requires": {
+        "nan": "^2.14.0"
       }
     },
     "tree-sitter-typescript": {

--- a/package.json
+++ b/package.json
@@ -3,18 +3,25 @@
   "version": "0.6.0",
   "description": "Cucumber Language Server",
   "type": "module",
-  "main": "dist/cjs/src/index.js",
-  "module": "dist/esm/src/index.js",
-  "types": "dist/esm/src/index.d.ts",
+  "main": "dist/cjs/src/node/startNodeServer.js",
+  "module": "dist/esm/src/node/startNodeServer.js",
+  "types": "dist/esm/src/node/startNodeServer.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/esm/src/index.js",
-      "require": "./dist/cjs/src/index.js"
+      "import": "./dist/esm/src/node/startNodeServer.js",
+      "require": "./dist/cjs/src/node/startNodeServer.js"
+    },
+    "./wasm": {
+      "import": "./dist/esm/src/wasm/startWasmServer.js",
+      "require": "./dist/cjs/src/wasm/startWasmServer.js"
     }
   },
   "files": [
     "dist/cjs/src",
-    "dist/esm/src"
+    "dist/cjs/package.json",
+    "dist/esm/src",
+    "node",
+    "wasm"
   ],
   "bin": {
     "cucumber-language-server": "bin/cucumber-language-server.cjs"
@@ -77,7 +84,7 @@
   "dependencies": {
     "@cucumber/cucumber-expressions": "^15.1.1",
     "@cucumber/gherkin-utils": "^7.0.0",
-    "@cucumber/language-service": "^0.14.4",
+    "@cucumber/language-service": "^0.15.0",
     "fast-glob": "3.2.11",
     "source-map-support": "0.5.21",
     "vscode-languageserver": "7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export * from './startServer.js'

--- a/src/loadAll.ts
+++ b/src/loadAll.ts
@@ -3,11 +3,13 @@ import fg from 'fast-glob'
 import fs from 'fs/promises'
 import path from 'path'
 
-type Extension = '.ts' | '.java'
+type Extension = '.ts' | '.java' | '.cs' | '.php'
 
 export const languageByExt: Record<Extension, LanguageName> = {
   '.ts': 'typescript',
   '.java': 'java',
+  '.cs': 'c_sharp',
+  '.php': 'php',
 }
 
 const extensions = Array.from(Object.keys(languageByExt)).concat('.feature')

--- a/src/node/startNodeServer.ts
+++ b/src/node/startNodeServer.ts
@@ -1,0 +1,7 @@
+import { NodeParserAdapter } from '@cucumber/language-service/node'
+
+import { startServer } from '../startServer'
+
+export function startNodeServer() {
+  startServer(new NodeParserAdapter())
+}

--- a/src/startServer.ts
+++ b/src/startServer.ts
@@ -1,8 +1,8 @@
+import { ParserAdapter } from '@cucumber/language-service'
 import { TextDocuments } from 'vscode-languageserver'
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
-import { ParserAdapter } from '../../language-service'
 import { CucumberLanguageServer } from './CucumberLanguageServer.js'
 
 export function startServer(adapter: ParserAdapter) {

--- a/src/startServer.ts
+++ b/src/startServer.ts
@@ -1,14 +1,14 @@
-import { ParserAdapter } from '@cucumber/language-service'
 import { TextDocuments } from 'vscode-languageserver'
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
+import { ParserAdapter } from '../../language-service'
 import { CucumberLanguageServer } from './CucumberLanguageServer.js'
 
 export function startServer(adapter: ParserAdapter) {
   const connection = createConnection(ProposedFeatures.all)
   const documents = new TextDocuments(TextDocument)
-  new CucumberLanguageServer(adapter, connection, documents)
+  new CucumberLanguageServer(connection, documents, adapter)
   connection.listen()
 
   // Don't die on unhandled Promise rejections

--- a/src/wasm/startWasmServer.ts
+++ b/src/wasm/startWasmServer.ts
@@ -1,0 +1,7 @@
+import { WasmParserAdapter } from '@cucumber/language-service/wasm'
+
+import { startServer } from '../startServer'
+
+export function startWasmServer(wasmBaseUrl: string) {
+  startServer(new WasmParserAdapter(wasmBaseUrl))
+}

--- a/test/CucumberLanguageServer.test.ts
+++ b/test/CucumberLanguageServer.test.ts
@@ -54,7 +54,7 @@ describe('CucumberLanguageServer', () => {
     serverConnection = createConnection(inputStream, outputStream)
     documents = new TextDocuments(TextDocument)
 
-    new CucumberLanguageServer(new NodeParserAdapter(), serverConnection, documents)
+    new CucumberLanguageServer(serverConnection, documents, new NodeParserAdapter())
     serverConnection.listen()
 
     const initializeParams: InitializeParams = {

--- a/tsconfig.build-cjs.json
+++ b/tsconfig.build-cjs.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "outDir": "dist/cjs",
-    "target": "ES5",
+    "target": "ES6",
     "module": "CommonJS",
-  },
+    "outDir": "dist/cjs"
+  }
 }

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wasm",
+  "description": "Cucumber Language server using tree-sitter wasm bindings",
+  "main": "../dist/cjs/src/wasm/startWasmServer.js",
+  "module": "../dist/esm/src/wasm/startWasmServer.js",
+  "types": "../dist/esm/src/wasm/startWasmServer.d.ts"
+}


### PR DESCRIPTION
### 🤔 What's changed?

Two new entry points have been added:
* `@cucumber/language-server` -> Node
* `@cucumber/language-server/wasm` -> Wasm

### ⚡️ What's your motivation? 

The Wasm binding is needed for the vscode extension, and it must be loaded without also loading the Node binding

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :boom: Breaking change (incompatible changes to the API)
