### PR TITLE
Update default globs to work with Pytest-BDD conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Update default globs to work with Pytest-BDD conventions
+- Update default globs to work with Pytest-BDD conventions ([#64](https://github.com/cucumber/language-server/pull/64)
 
 ## [0.12.12] - 2022-08-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Update default globs to work with Pytest-BDD conventions
+
 ## [0.12.12] - 2022-08-27
 ### Fixed
 - Add default values for Python [#63](https://github.com/cucumber/language-server/pull/63)

--- a/src/CucumberLanguageServer.ts
+++ b/src/CucumberLanguageServer.ts
@@ -45,13 +45,32 @@ type ServerInfo = {
 // This should be consistent with the `README.md` in `cucumber/vscode` - this is to
 // ensure the docs for the plugin reflect the defaults.
 const defaultSettings: Settings = {
-  features: ['src/test/**/*.feature', 'features/**/*.feature'],
+  // IMPORTANT: If you change features or glue below, please also create a PR to update
+  // the vscode extension defaults accordingly in https://github.com/cucumber/vscode/blob/main/README.md#extension-settings
+  features: [
+    // Cucumber-JVM
+    'src/test/**/*.feature',
+    // Cucumber-Ruby, Cucumber-Js, Behat, Behave
+    'features/**/*.feature',
+    // Pytest-BDD
+    'tests/**/*.feature',
+    // SpecFlow
+    '*specs*/**/.feature',
+  ],
   glue: [
+    // Cucumber-JVM
     'src/test/**/*.java',
+    // Cucumber-Js
     'features/**/*.ts',
+    // Behave
     'features/**/*.php',
+    // Behat
     'features/**/*.py',
+    // Pytest-BDD
+    'tests/**/*.py',
+    // Cucumber-Ruby
     'features/**/*.rb',
+    // SpecFlow
     '*specs*/**/.cs',
   ],
   parameterTypes: [],


### PR DESCRIPTION
### 🤔 What's changed?

The globs for finding step definitions

### ⚡️ What's your motivation? 

Work out of the box with pytest-bdd conventions. See https://github.com/cucumber/language-service/pull/84#issuecomment-1229978912

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
