### PR TITLE
Add support for document symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix rust snippet fn name to lowercase ([#103](https://github.com/cucumber/language-service/issues/103), [#104](https://github.com/cucumber/language-service/pull/104))
 
+### Added
+- Add support for [document symbols](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol) ([#98](https://github.com/cucumber/language-service/issues/98), [#106](https://github.com/cucumber/language-service/pull/106))
+- (Java) Recognise regexps with `(?i)`, with the caveat that the resulting JavaScript `RegExp` is _not_ case insensitive ([#100](https://github.com/cucumber/language-service/issues/100), [#108](https://github.com/cucumber/language-service/pull/108))
+- (TypeScript) Add support for template literals without subsitutions. ([#101](https://github.com/cucumber/language-service/issues/101), [#107](https://github.com/cucumber/language-service/pull/107))
+
 ## [1.0.0] - 2022-10-05
 ### Added
 - Support for [Cucumber Rust](https://github.com/cucumber-rs/cucumber) ([#82](https://github.com/cucumber/language-service/issues/82), [#99](https://github.com/cucumber/language-service/pull/99))

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@cucumber/gherkin-utils": "^8.0.0",
-        "@cucumber/language-service": "^1.0.1",
+        "@cucumber/language-service": "^1.1.0",
         "fast-glob": "3.2.12",
         "source-map-support": "0.5.21",
         "vscode-languageserver": "8.0.2",
@@ -148,6 +148,7 @@
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-24.0.0.tgz",
       "integrity": "sha512-b7OsnvX1B8myDAKMc+RAiUX9bzgtNdjGsiMj10O13xu2HBWIOQ19EqBJ4xLO5CFG/lGk1J/+L0lANQVowxLVBg==",
+      "dev": true,
       "dependencies": {
         "@cucumber/messages": "^19.0.0"
       }
@@ -202,14 +203,14 @@
       }
     },
     "node_modules/@cucumber/language-service": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-1.0.1.tgz",
-      "integrity": "sha512-hk+dBd6ynJSgfYCm97EbO1lzNN3Ymp6s6FKT/bY2711TjlYj1WVSXX5Th37fGugsNb2dgxOq4uXuZywgGUwLEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-1.1.0.tgz",
+      "integrity": "sha512-vRoekdEcv+gJ2aYXR36nS2/w92PkXYwNqr3OHOyxhAoHnA4+jG/4qax2GsjjZxe0ZnvGbxOoDMhrj6IxdqFo5A==",
       "dependencies": {
         "@cucumber/cucumber-expressions": "^16.0.0",
-        "@cucumber/gherkin": "^24.0.0",
+        "@cucumber/gherkin": "^24.1.0",
         "@cucumber/gherkin-utils": "^8.0.0",
-        "@cucumber/messages": "^19.1.2",
+        "@cucumber/messages": "^19.1.4",
         "@types/js-search": "1.4.0",
         "@types/mustache": "4.2.1",
         "fuse.js": "6.6.2",
@@ -231,6 +232,33 @@
       },
       "peerDependencies": {
         "web-tree-sitter": "^0.20.7"
+      }
+    },
+    "node_modules/@cucumber/language-service/node_modules/@cucumber/gherkin": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-24.1.0.tgz",
+      "integrity": "sha512-B48XrUod4y3SoXe6mv12q7U1zThUNSK3yHSm/hBJCJZ6RJUJhFk3FVMN/83qOEbsYZe6iG9v+4L1Myf8/q8C6g==",
+      "dependencies": {
+        "@cucumber/messages": "^19.1.4"
+      }
+    },
+    "node_modules/@cucumber/language-service/node_modules/@cucumber/messages": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
+      "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
+      "dependencies": {
+        "@types/uuid": "8.3.4",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.1.13",
+        "uuid": "9.0.0"
+      }
+    },
+    "node_modules/@cucumber/language-service/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cucumber/message-streams": {
@@ -7783,6 +7811,7 @@
       "version": "24.0.0",
       "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-24.0.0.tgz",
       "integrity": "sha512-b7OsnvX1B8myDAKMc+RAiUX9bzgtNdjGsiMj10O13xu2HBWIOQ19EqBJ4xLO5CFG/lGk1J/+L0lANQVowxLVBg==",
+      "dev": true,
       "requires": {
         "@cucumber/messages": "^19.0.0"
       }
@@ -7823,14 +7852,14 @@
       "requires": {}
     },
     "@cucumber/language-service": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-1.0.1.tgz",
-      "integrity": "sha512-hk+dBd6ynJSgfYCm97EbO1lzNN3Ymp6s6FKT/bY2711TjlYj1WVSXX5Th37fGugsNb2dgxOq4uXuZywgGUwLEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/language-service/-/language-service-1.1.0.tgz",
+      "integrity": "sha512-vRoekdEcv+gJ2aYXR36nS2/w92PkXYwNqr3OHOyxhAoHnA4+jG/4qax2GsjjZxe0ZnvGbxOoDMhrj6IxdqFo5A==",
       "requires": {
         "@cucumber/cucumber-expressions": "^16.0.0",
-        "@cucumber/gherkin": "^24.0.0",
+        "@cucumber/gherkin": "^24.1.0",
         "@cucumber/gherkin-utils": "^8.0.0",
-        "@cucumber/messages": "^19.1.2",
+        "@cucumber/messages": "^19.1.4",
         "@types/js-search": "1.4.0",
         "@types/mustache": "4.2.1",
         "fuse.js": "6.6.2",
@@ -7847,6 +7876,32 @@
         "tree-sitter-typescript": "0.20.1",
         "vscode-languageserver-types": "3.17.2",
         "web-tree-sitter": "^0.20.7"
+      },
+      "dependencies": {
+        "@cucumber/gherkin": {
+          "version": "24.1.0",
+          "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-24.1.0.tgz",
+          "integrity": "sha512-B48XrUod4y3SoXe6mv12q7U1zThUNSK3yHSm/hBJCJZ6RJUJhFk3FVMN/83qOEbsYZe6iG9v+4L1Myf8/q8C6g==",
+          "requires": {
+            "@cucumber/messages": "^19.1.4"
+          }
+        },
+        "@cucumber/messages": {
+          "version": "19.1.4",
+          "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
+          "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
+          "requires": {
+            "@types/uuid": "8.3.4",
+            "class-transformer": "0.5.1",
+            "reflect-metadata": "0.1.13",
+            "uuid": "9.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
       }
     },
     "@cucumber/message-streams": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@cucumber/gherkin-utils": "^8.0.0",
-    "@cucumber/language-service": "^1.0.1",
+    "@cucumber/language-service": "^1.1.0",
     "fast-glob": "3.2.12",
     "source-map-support": "0.5.21",
     "vscode-languageserver": "8.0.2",

--- a/src/CucumberLanguageServer.ts
+++ b/src/CucumberLanguageServer.ts
@@ -5,6 +5,7 @@ import {
   getGenerateSnippetCodeAction,
   getGherkinCompletionItems,
   getGherkinDiagnostics,
+  getGherkinDocumentFeatureSymbol,
   getGherkinFormattingEdits,
   getGherkinSemanticTokens,
   getStepDefinitionLocationLinks,
@@ -261,6 +262,18 @@ export class CucumberLanguageServer {
         connection.console.info('onDefinition is disabled')
       }
 
+      if (params.capabilities.textDocument?.documentSymbol) {
+        connection.onDocumentSymbol((params) => {
+          const doc = documents.get(params.textDocument.uri)
+          if (!doc) return []
+          const gherkinSource = doc.getText()
+          const symbol = getGherkinDocumentFeatureSymbol(gherkinSource)
+          return symbol ? [symbol] : null
+        })
+      } else {
+        connection.console.info('onDocumentSymbol is disabled')
+      }
+
       return {
         capabilities: this.capabilities(),
         serverInfo: this.info(),
@@ -310,6 +323,9 @@ export class CucumberLanguageServer {
           tokenTypes: semanticTokenTypes,
           tokenModifiers: [],
         },
+      },
+      documentSymbolProvider: {
+        label: 'Cucumber',
       },
       documentFormattingProvider: true,
       definitionProvider: true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.13.1'
+export const version = '1.0.0'


### PR DESCRIPTION
### 🤔 What's changed?

Add support for LSP document symbols

### ⚡️ What's your motivation? 

Display an outline of a Gherkin document

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
