### PR TITLE
fix(startup): fix start standalone outside vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed c-sharp glob paths for step definitions and feature files - [#89](https://github.com/cucumber/language-server/pull/89)
 - Specify minimum supported node version ([#100](https://github.com/cucumber/language-server/pull/100))
+- Fixed the issue preventing standalone operation outside of VS Code - [#74](https://github.com/cucumber/language-server/pull/74)
 
 ### Added
 - Allow Javascript/Typescript glue files with the following file extensions: cjs, mjs, cts, mts - [#85](https://github.com/cucumber/language-server/pull/85)

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ provide them.
 The server retrieves `cucumber.*` settings from the client with a [workspace/configuration](https://microsoft.github.io/language-server-protocol/specification#workspace_configuration) request.
 
 See [Settings](https://github.com/cucumber/language-server/blob/main/src/types.ts) for details about the expected format.
+
+## External VSCode Usage
+
+We've encountered an issue with the Node version used by [Treesitter](https://github.com/tree-sitter/tree-sitter/issues/2338), a
+dependency of this language server, when working outside of VSCode. For optimal
+compatibility, please use the same Node version as version 18 of VSCode.

--- a/bin/cucumber-language-server.cjs
+++ b/bin/cucumber-language-server.cjs
@@ -3,13 +3,11 @@
 require('source-map-support').install()
 const { startStandaloneServer } = require('../dist/cjs/src/wasm/startStandaloneServer')
 const { NodeFiles } = require('../dist/cjs/src/node/NodeFiles')
-const url = require('url')
-const { version } = require('../src/version')
+const path = require('path')
+const { version } = require('../dist/cjs/src/version')
 
-const wasmBaseUrl = url.pathToFileURL(
-  `${__dirname}/../node_modules/@cucumber/language-service/dist`
-)
-const { connection } = startStandaloneServer(wasmBaseUrl.href, (rootUri) => new NodeFiles(rootUri))
+const wasmBasePath = path.resolve(`${__dirname}/../node_modules/@cucumber/language-service/dist`)
+const { connection } = startStandaloneServer(wasmBasePath, (rootUri) => new NodeFiles(rootUri))
 
 // Don't die on unhandled Promise rejections
 process.on('unhandledRejection', (reason, p) => {

--- a/src/wasm/startStandaloneServer.ts
+++ b/src/wasm/startStandaloneServer.ts
@@ -12,4 +12,8 @@ export function startStandaloneServer(wasmBaseUrl: string, makeFiles: (rootUri: 
   const documents = new TextDocuments(TextDocument)
   new CucumberLanguageServer(connection, documents, adapter, makeFiles, () => undefined)
   connection.listen()
+
+  return {
+    connection,
+  }
 }

--- a/test/CucumberLanguageServer.test.ts
+++ b/test/CucumberLanguageServer.test.ts
@@ -1,7 +1,7 @@
 import { WasmParserAdapter } from '@cucumber/language-service/wasm'
 import assert from 'assert'
 import { Duplex } from 'stream'
-import { Logger, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node'
+import { NullLogger, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node'
 import {
   Connection,
   createProtocolConnection,
@@ -80,11 +80,10 @@ describe('CucumberLanguageServer', () => {
       },
       workspaceFolders: null,
     }
-    const logger = new NullLogger()
     clientConnection = createProtocolConnection(
       new StreamMessageReader(outputStream),
       new StreamMessageWriter(inputStream),
-      logger
+      NullLogger
     )
     clientConnection.onError((err) => {
       console.error('ERROR', err)
@@ -203,24 +202,6 @@ class TestStream extends Duplex {
   }
 
   _read() {
-    // no-op
-  }
-}
-
-class NullLogger implements Logger {
-  error(): void {
-    // no-op
-  }
-
-  warn(): void {
-    // no-op
-  }
-
-  info(): void {
-    // no-op
-  }
-
-  log(): void {
     // no-op
   }
 }

--- a/test/standalone.test.ts
+++ b/test/standalone.test.ts
@@ -1,0 +1,125 @@
+import assert from 'assert'
+import { ChildProcess, fork } from 'child_process'
+import { Duplex } from 'stream'
+import { NullLogger, StreamMessageReader, StreamMessageWriter } from 'vscode-jsonrpc/node'
+import {
+  createProtocolConnection,
+  DidChangeConfigurationNotification,
+  DidChangeConfigurationParams,
+  InitializeParams,
+  InitializeRequest,
+  LogMessageNotification,
+  LogMessageParams,
+  ProtocolConnection,
+} from 'vscode-languageserver'
+
+import { Settings } from '../src/types.js'
+
+describe('Standalone', () => {
+  let serverFork: ChildProcess
+  let logMessages: LogMessageParams[]
+  let clientConnection: ProtocolConnection
+
+  beforeEach(async () => {
+    logMessages = []
+    serverFork = fork('./bin/cucumber-language-server.cjs', ['--stdio'], {
+      silent: true,
+    })
+
+    const initializeParams: InitializeParams = {
+      rootUri: `file://${process.cwd()}`,
+      processId: NaN, // This id is used by vscode-languageserver. Set as NaN so that the watchdog responsible for watching this process does not run.
+      capabilities: {
+        workspace: {
+          configuration: true,
+          didChangeWatchedFiles: {
+            dynamicRegistration: true,
+          },
+        },
+        textDocument: {
+          moniker: {
+            dynamicRegistration: false,
+          },
+          completion: {
+            completionItem: {
+              snippetSupport: true,
+            },
+          },
+          semanticTokens: {
+            tokenTypes: [],
+            tokenModifiers: [],
+            formats: [],
+            requests: {},
+          },
+          formatting: {
+            dynamicRegistration: true,
+          },
+        },
+      },
+      workspaceFolders: null,
+    }
+    if (!serverFork.stdin || !serverFork.stdout) {
+      throw 'Process created without stdio streams'
+    }
+    clientConnection = createProtocolConnection(
+      new StreamMessageReader(serverFork.stdout as Duplex),
+      new StreamMessageWriter(serverFork.stdin as Duplex),
+      NullLogger
+    )
+    clientConnection.onError((err) => {
+      console.error('ERROR', err)
+    })
+    clientConnection.onNotification(LogMessageNotification.type, (params) => {
+      if (params.type !== 3) {
+        logMessages.push(params)
+      }
+    })
+    clientConnection.onUnhandledNotification((n) => {
+      console.error('Unhandled notification', n)
+    })
+    clientConnection.listen()
+    const { serverInfo } = await clientConnection.sendRequest(
+      InitializeRequest.type,
+      initializeParams
+    )
+    assert.strictEqual(serverInfo?.name, 'Cucumber Language Server')
+  })
+
+  afterEach(() => {
+    clientConnection.end()
+    clientConnection.dispose()
+    serverFork.kill('SIGTERM') // Try to terminate first
+    serverFork.kill('SIGKILL') // Then try to kill if it is not killed
+  })
+
+  context('workspace/didChangeConfiguration', () => {
+    it(`startup success`, async () => {
+      // First we need to configure the server, telling it where to find Gherkin documents and Glue code.
+      // Note that *pushing* settings from the client to the server is deprecated in the LSP. We're only using it
+      // here because it's easier to implement in the test.
+      const settings: Settings = {
+        features: ['testdata/**/*.feature'],
+        glue: ['testdata/**/*.js'],
+        parameterTypes: [],
+        snippetTemplates: {},
+      }
+      const configParams: DidChangeConfigurationParams = {
+        settings,
+      }
+
+      await clientConnection.sendNotification(DidChangeConfigurationNotification.type, configParams)
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+
+      assert.strictEqual(
+        logMessages.length,
+        // TODO: change this to 0 when `workspace/semanticTokens/refresh` issue was solved
+        1,
+        // print readable log messages
+        logMessages
+          .map(({ type, message }) => `**Type**: ${type}\n**Message**:\n${message}\n`)
+          .join('\n--------------------\n')
+      )
+    })
+  })
+})


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->
Fixes #72, #79, #90, #96

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

First, The `url.pathToFileURL` was introduced by #68 to fix #66 but it did not fix the problem and #66 was closed by using another product.

After that, the #73 change how `language-server` worked. It refactor `src/wasm/startWasmServer.ts` into `src/wasm/startEmbeddedServer.ts` and `src/wasm/startStandaloneServer.ts`. The `startEmbeddedServer` is used for VS Code with browser support and the `startStandaloneServer` is used as fallback for user outside of VS Code but it was not tested properly.

As a result, the language server is rendered unusable outside of VS Code, and this PR aims to rectify this issue.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
