### PR TITLE
Support cjs/mjs/cts/mts glue extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Allow Javascript/Typescript glue files with the following file extensions: cjs, mjs, cts, mts - [#85](https://github.com/cucumber/language-server/pull/85)
+
 ## [1.4.0] - 2022-12-08
 ### Added
 - Added support for JavaScript - [#42](https://github.com/cucumber/language-service/issues/42), [#115](https://github.com/cucumber/language-service/pull/115), [#120](https://github.com/cucumber/language-service/pull/120)

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -3,8 +3,8 @@ import { LanguageName, Source } from '@cucumber/language-service'
 import { extname, Files } from './Files.js'
 
 export const glueExtByLanguageName: Record<LanguageName, string[]> = {
-  javascript: ['.js', '.jsx'],
-  tsx: ['.ts', '.tsx'],
+  javascript: ['.js', '.cjs', '.mjs', '.jsx'],
+  tsx: ['.ts', '.cts', '.mts', '.tsx'],
   java: ['.java'],
   c_sharp: ['.cs'],
   php: ['.php'],

--- a/test/CucumberLanguageServer.test.ts
+++ b/test/CucumberLanguageServer.test.ts
@@ -50,7 +50,7 @@ describe('CucumberLanguageServer', () => {
 
     const initializeParams: InitializeParams = {
       rootUri: `file://${process.cwd()}`,
-      processId: 'N/A' as unknown as number, // This id is used by vscode-languageserver. Forcing this to be a string so that the watchdog responsible for watching this process does not run.
+      processId: NaN, // This id is used by vscode-languageserver. Set as NaN so that the watchdog responsible for watching this process does not run.
       capabilities: {
         workspace: {
           configuration: true,

--- a/test/CucumberLanguageServer.test.ts
+++ b/test/CucumberLanguageServer.test.ts
@@ -109,10 +109,20 @@ describe('CucumberLanguageServer', () => {
   })
 
   context('textDocument/completion', () => {
-    const typescriptFileExtensions = ['ts', 'cts', 'mts']
+    const fileExtensions = [
+      // Javascript
+      'js',
+      'cjs',
+      'mjs',
 
-    typescriptFileExtensions.forEach((fileExtension) =>
-      it(`returns completion items for *.${fileExtension} typescript files`, async () => {
+      // Typescript
+      'ts',
+      'cts',
+      'mts',
+    ]
+
+    fileExtensions.forEach((fileExtension) =>
+      it(`returns completion items for *.${fileExtension} files`, async () => {
         // First we need to configure the server, telling it where to find Gherkin documents and Glue code.
         // Note that *pushing* settings from the client to the server is deprecated in the LSP. We're only using it
         // here because it's easier to implement in the test.

--- a/test/CucumberLanguageServer.test.ts
+++ b/test/CucumberLanguageServer.test.ts
@@ -50,7 +50,7 @@ describe('CucumberLanguageServer', () => {
 
     const initializeParams: InitializeParams = {
       rootUri: `file://${process.cwd()}`,
-      processId: 1,
+      processId: 'N/A' as unknown as number, // This id is used by vscode-languageserver. Forcing this to be a string so that the watchdog responsible for watching this process does not run.
       capabilities: {
         workspace: {
           configuration: true,

--- a/testdata/javascript/stepdefs.cjs
+++ b/testdata/javascript/stepdefs.cjs
@@ -1,0 +1,4 @@
+import { Given } from '@cucumber/cucumber'
+import assert from 'assert'
+
+Given('I have {int} cukes', (count) => assert(count))

--- a/testdata/javascript/stepdefs.js
+++ b/testdata/javascript/stepdefs.js
@@ -1,0 +1,4 @@
+import { Given } from '@cucumber/cucumber'
+import assert from 'assert'
+
+Given('I have {int} cukes', (count) => assert(count))

--- a/testdata/javascript/stepdefs.mjs
+++ b/testdata/javascript/stepdefs.mjs
@@ -1,0 +1,4 @@
+import { Given } from '@cucumber/cucumber'
+import assert from 'assert'
+
+Given('I have {int} cukes', (count) => assert(count))

--- a/testdata/typescript/stepdefs.cts
+++ b/testdata/typescript/stepdefs.cts
@@ -1,0 +1,4 @@
+import { Given } from '@cucumber/cucumber'
+import assert from 'assert'
+
+Given('I have {int} cukes', (count: number) => assert(count))

--- a/testdata/typescript/stepdefs.mts
+++ b/testdata/typescript/stepdefs.mts
@@ -1,0 +1,4 @@
+import { Given } from '@cucumber/cucumber'
+import assert from 'assert'
+
+Given('I have {int} cukes', (count: number) => assert(count))


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

<!-- Describe your changes in detail -->

This PR adds support for glue files with the following file extensions:
- Javascript: `*.cjs`, `*.mjs`
- Typescript: `*.cts`, `*.mts`

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

I wanted to use `*.mjs` glue files to keep consistency with the rest of my repository.

Fixes #78 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

I decided not to edit the default settings since I'm not aware of what it might affect.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] ~My change requires a change to the documentation.~ N/A
  - [x] ~I have updated the documentation accordingly.~ N/A
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
