### PR TITLE
Glob paths not matching c-sharp files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fixed c-sharp glob paths for step definitions and feature files - [#89](https://github.com/cucumber/language-server/pull/89)
+
 ### Added
 - Allow Javascript/Typescript glue files with the following file extensions: cjs, mjs, cts, mts - [#85](https://github.com/cucumber/language-server/pull/85)
 

--- a/src/CucumberLanguageServer.ts
+++ b/src/CucumberLanguageServer.ts
@@ -54,7 +54,7 @@ const defaultSettings: Settings = {
     // Pytest-BDD
     'tests/**/*.feature',
     // SpecFlow
-    '*specs*/**/.feature',
+    '*specs*/**/*.feature',
   ],
   glue: [
     // Cucumber-JVM
@@ -64,9 +64,9 @@ const defaultSettings: Settings = {
     'features/**/*.tsx',
     'features/**/*.js',
     'features/**/*.jsx',
-    // Behave
-    'features/**/*.php',
     // Behat
+    'features/**/*.php',
+    // Behave
     'features/**/*.py',
     // Pytest-BDD
     'tests/**/*.py',
@@ -76,7 +76,7 @@ const defaultSettings: Settings = {
     // Cucumber-Ruby
     'features/**/*.rb',
     // SpecFlow
-    '*specs*/**/.cs',
+    '*specs*/**/*.cs',
   ],
   parameterTypes: [],
   snippetTemplates: {},


### PR DESCRIPTION
The default glob paths for c-sharp step definition and feature files match the names that contain only the file extension (no stem) - e.g. complete filenames called `.cs` and `.feature` - thus must be configured by the user in all cases at present.

```typescript
{
  features: [
     ...
     '*specs*/**/.feature',
   ],
   glue: [
     ...
     '*specs*/**/.cs',
  ]
}
```

### 🤔 What's changed?

- Updated SpecFlow glob paths to match c-sharp file extensions
- Reordered comments for Behave and Behat to ensure they label their respective glob patterns appropriately

```typescript
{
  features: [
     ...
     '*specs*/**/*.feature',
   ],
   glue: [
     ...
     '*specs*/**/*.cs',
  ]
}
```

### ⚡️ What's your motivation? 

- Ensure c-sharp patterns are matched through smart defaults without additional configuration
- Align with the respective pull request by @margori cucumber/vscode#144

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.