### PR TITLE
Drop Renovate dependency dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,5 @@
   "extends": [
     "github>cucumber/renovate-config",
     ":automergeMajor"
-  ],
-  "dependencyDashboard": true
+  ]
 }


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

- Removed Renovate's dependency dashboard

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

- Closes #81
- Unused as the [inherited Renovate configuration](https://github.com/cucumber/renovate-config/blob/991c318c6b92634e14deee241b443962f7965618/default.json) automatically performs rebases and PRs can be individually rebased - mitigating need of the dashboard
- Aligns with the [Language Service Renovate configuration](https://github.com/cucumber/language-service/blob/main/.github/renovate.json)

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)