### PR TITLE
feat: add Kotlin/Scala glue file support and fix two bugs

### DIFF
--- a/bin/cucumber-language-server.cjs
+++ b/bin/cucumber-language-server.cjs
@@ -6,7 +6,10 @@ const { NodeFiles } = require('../dist/cjs/src/node/NodeFiles')
 const path = require('path')
 const { version } = require('../dist/cjs/src/version')
 
-const wasmBasePath = path.resolve(`${__dirname}/../node_modules/@cucumber/language-service/dist`)
+// Use require.resolve so this works regardless of whether npm hoisted
+// @cucumber/language-service or installed it nested inside our node_modules.
+// Main CJS entry is dist/cjs/src/index.js — go up two dirs to reach dist/.
+const wasmBasePath = path.join(path.dirname(require.resolve('@cucumber/language-service')), '../..')
 const { connection } = startStandaloneServer(wasmBasePath, (rootUri) => new NodeFiles(rootUri))
 
 // Don't die on unhandled Promise rejections

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@cucumber/gherkin-utils": "^12.0.0",
-    "@cucumber/language-service": "^1.7.0",
+    "@cucumber/language-service": "github:marton78/language-service#kotlin-support",
     "fast-glob": "3.3.3",
     "source-map-support": "0.5.21",
     "vscode-languageserver": "8.0.2",

--- a/src/CucumberLanguageServer.ts
+++ b/src/CucumberLanguageServer.ts
@@ -136,7 +136,14 @@ export class CucumberLanguageServer {
       if (params.capabilities.workspace?.configuration) {
         connection.onDidChangeConfiguration((params) => {
           this.connection.console.info(`Client sent workspace/configuration`)
-          this.reindex(<Settings>params.settings).catch((err) => {
+          // params.settings may be null or missing features/glue depending on the client;
+          // only use it if it looks like a valid Settings object, otherwise fall back to
+          // getSettings() to avoid a crash on undefined.reduce() during reindex.
+          const settings =
+            params.settings?.features != null && params.settings?.glue != null
+              ? (params.settings as Settings)
+              : undefined
+          this.reindex(settings).catch((err) => {
             connection.console.error(`Failed to reindex: ${err.message}`)
           })
         })

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -12,6 +12,8 @@ export const glueExtByLanguageName: Record<LanguageName, string[]> = {
   python: ['.py'],
   rust: ['.rs'],
   go: ['.go'],
+  scala: ['.scala'],
+  kotlin: ['.kt', '.kts'],
 }
 
 type ExtLangEntry = [string, LanguageName]


### PR DESCRIPTION
## Summary

- Adds `kotlin` (`.kt`/`.kts`) and `scala` (`.scala`) to `glueExtByLanguageName` so the server discovers step definitions in those files
- **Fix:** reindex crash when `DidChangeConfiguration` sends `null`/malformed settings — `params.settings` was blindly cast to `Settings`, causing `undefined.reduce()` if `features`/`glue` were missing (observed with Zed)
- **Fix:** `wasmBasePath` resolved incorrectly when npm hoists `@cucumber/language-service`; now uses `require.resolve()` instead of the hardcoded `__dirname/../node_modules` path

## Dependency chain

This PR is a part of two, adding Kotlin support:

1. `cucumber/language-service` [#304](https://github.com/cucumber/language-service/pull/304) — Kotlin parsing *(merge first)*
2. **This PR** — glue file discovery + two bug fixes

> Note: the `package.json` currently points at `marton78/language-service#kotlin-support` for development; this should be updated to the official release once PR #304 merges.

## Test plan

- [x] `.kt` and `.kts` files are indexed as glue files
- [x] `.scala` files are indexed as glue files
- [x] No crash when Zed sends `DidChangeConfiguration` with null/missing settings
- [x] `wasmBasePath` resolves correctly when `@cucumber/language-service` is hoisted by npm