### PR TITLE
Add support for clojure language

### DIFF
--- a/src/CucumberLanguageServer.ts
+++ b/src/CucumberLanguageServer.ts
@@ -79,6 +79,8 @@ const defaultSettings: Settings = {
     '*specs*/**/*.cs',
     // Godog
     'features/**/*_test.go',
+    // Cucumber-Clojure
+    'features/**/*.clj',
   ],
   parameterTypes: [],
   snippetTemplates: {},

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -7,11 +7,13 @@ export const glueExtByLanguageName: Record<LanguageName, string[]> = {
   tsx: ['.ts', '.cts', '.mts', '.tsx'],
   java: ['.java'],
   c_sharp: ['.cs'],
+  clojure: ['.clj', '.cljc', '.cljs'],
   php: ['.php'],
   ruby: ['.rb'],
   python: ['.py'],
   rust: ['.rs'],
   go: ['.go'],
+  scala: ['.scala'],
 }
 
 type ExtLangEntry = [string, LanguageName]


### PR DESCRIPTION
### 🤔 What's changed?

Added support for the Clojure language.

### ⚡️ What's your motivation? 

Currently, the Cucumber plugin in Vscode does not recognise step definitions written in clojure. This is the sedond step; and relies on the merge and release of https://github.com/cucumber/language-service/pull/309.  The final step will be:

cucumber/vscode — Add { scheme: 'file', language: 'clojure' } to documentSelector in src/extension.ts, and add .clj glue patterns to the defaults in package.json, and update dependencies.

No tests were added - there are no existing tests for other languages at this level.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.